### PR TITLE
[IMP] purchase_analytic: improve tests to increase coverage

### DIFF
--- a/purchase_analytic/tests/test_purchase_analytic.py
+++ b/purchase_analytic/tests/test_purchase_analytic.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime
 
+from odoo import Command
 from odoo.tests.common import TransactionCase
 
 
@@ -17,65 +18,74 @@ class TestPurchaseAnalytic(TransactionCase):
             {"name": "manual", "plan_id": analytic_plan.id}
         )
         self.analytic_distribution_manual = {str(analytic_account_manual.id): 100}
+        self.analytic_distribution_manual2 = {str(analytic_account_manual.id): 50}
 
-    def test_analytic_distribution(self):
+    def add_new_order_line(self):
+        return [
+            Command.create(
+                {
+                    "name": self.product_id.name,
+                    "product_id": self.product_id.id,
+                    "product_qty": 1.0,
+                    "product_uom": self.uom_id.id,
+                    "price_unit": 121.0,
+                    "date_planned": datetime.today(),
+                }
+            )
+        ]
+
+    def test_analytic_distribution_with_create(self):
         """Create a purchase order (create)
         Set analytic distribution on purchase
         Check analytic distribution and line is set
         """
-        po = self.env["purchase.order"].create(
-            {
-                "partner_id": self.partner_id.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": self.product_id.name,
-                            "product_id": self.product_id.id,
-                            "product_qty": 1.0,
-                            "product_uom": self.uom_id.id,
-                            "price_unit": 121.0,
-                            "date_planned": datetime.today(),
-                        },
-                    )
-                ],
-            }
-        )
+        po = self.env["purchase.order"].create({"partner_id": self.partner_id.id})
+
+        # Test setting analytic distribution without order lines
         po.analytic_distribution = self.analytic_distribution_manual
         po._onchange_analytic_distribution()
         self.assertEqual(po.analytic_distribution, self.analytic_distribution_manual)
+
+        # Test setting analytic distribution with an order line
+        po.order_line = self.add_new_order_line()
+        po.analytic_distribution = self.analytic_distribution_manual2
+        po._onchange_analytic_distribution()
+        self.assertEqual(po.analytic_distribution, self.analytic_distribution_manual2)
         self.assertEqual(
-            po.order_line.analytic_distribution, self.analytic_distribution_manual
+            po.order_line.analytic_distribution, self.analytic_distribution_manual2
         )
 
-    def test_analytic_disctribution_with_new(self):
+        # Test clearing analytic distribution with an order line
+        po.analytic_distribution = False
+        po._onchange_analytic_distribution()
+        self.assertEqual(
+            po.order_line.analytic_distribution, self.analytic_distribution_manual2
+        )
+
+    def test_analytic_distribution_with_new(self):
         """Create a purchase order (new)
         Set analytic distribution on purchase
         Check analytic distribution and line is set
         """
-        po = self.env["purchase.order"].new(
-            {
-                "partner_id": self.partner_id.id,
-                "analytic_distribution": self.analytic_distribution_manual,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": self.product_id.name,
-                            "product_id": self.product_id.id,
-                            "product_qty": 1.0,
-                            "product_uom": self.uom_id.id,
-                            "price_unit": 121.0,
-                            "date_planned": datetime.today(),
-                        },
-                    )
-                ],
-            }
-        )
+        po = self.env["purchase.order"].new({"partner_id": self.partner_id.id})
+
+        # Test setting analytic distribution without order lines
+        po.analytic_distribution = self.analytic_distribution_manual
         po._onchange_analytic_distribution()
         self.assertEqual(po.analytic_distribution, self.analytic_distribution_manual)
+
+        # Test setting analytic distribution with an order line
+        po.order_line = self.add_new_order_line()
+        po.analytic_distribution = self.analytic_distribution_manual2
+        po._onchange_analytic_distribution()
+        self.assertEqual(po.analytic_distribution, self.analytic_distribution_manual2)
         self.assertEqual(
-            po.order_line.analytic_distribution, self.analytic_distribution_manual
+            po.order_line.analytic_distribution, self.analytic_distribution_manual2
+        )
+
+        # Test clearing analytic distribution with an order line
+        po.analytic_distribution = False
+        po._onchange_analytic_distribution()
+        self.assertEqual(
+            po.order_line.analytic_distribution, self.analytic_distribution_manual2
         )


### PR DESCRIPTION
Add cases for setting the analytic distribution on a purchase order without lines and unsetting the analytic distribution on a purchase order with lines.